### PR TITLE
add `filter` to `move_and_slide`

### DIFF
--- a/src/movement.rs
+++ b/src/movement.rs
@@ -1,6 +1,8 @@
 use std::f32::consts::PI;
 
-use avian3d::prelude::{Collider, RigidBody, ShapeCastConfig, SpatialQuery, SpatialQueryFilter};
+use avian3d::prelude::{
+    Collider, CollisionLayers, RigidBody, ShapeCastConfig, SpatialQuery, SpatialQueryFilter,
+};
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{ActionState, Actions};
 
@@ -42,7 +44,16 @@ impl Default for KCCBundle {
 const EXAMPLE_MOVEMENT_SPEED: f32 = 8.0;
 
 fn movement(
-    mut q_kcc: Query<(Entity, &mut Transform, &mut KinematicVelocity, &Collider), With<KCCMarker>>,
+    mut q_kcc: Query<
+        (
+            Entity,
+            &mut Transform,
+            &mut KinematicVelocity,
+            &Collider,
+            &CollisionLayers,
+        ),
+        With<KCCMarker>,
+    >,
     q_input: Single<&Actions<DefaultContext>>,
     q_camera: Query<&Transform, (With<DefaultCamera>, Without<KCCMarker>)>,
     time: Res<Time>,
@@ -61,7 +72,8 @@ fn movement(
     // Get the raw 2D input vector
     let input_vec = q_input.action::<Move>().value().as_axis2d();
 
-    let Some((entity, mut kcc_transform, mut kinematic_vel, collider)) = q_kcc.single_mut().ok()
+    let Some((entity, mut kcc_transform, mut kinematic_vel, collider, layers)) =
+        q_kcc.single_mut().ok()
     else {
         warn!("No KCC found!");
         return;
@@ -79,14 +91,16 @@ fn movement(
     // Apply the final movement
     // kcc_transform.translation += direction * EXAMPLE_MOVEMENT_SPEED * time.delta_secs();
 
+    let filter = SpatialQueryFilter::from_mask(layers.filters).with_excluded_entities([entity]);
+
     move_and_slide(
         MoveAndSlideConfig::default(),
         collider,
         time.delta_secs(),
-        &entity,
         &mut kcc_transform,
         &mut artifical_velocity,
         &spatial_query,
+        &filter,
     )
 }
 
@@ -109,13 +123,11 @@ pub fn move_and_slide(
     config: MoveAndSlideConfig,
     collider: &Collider,
     delta_time: f32,
-    entity: &Entity,
     transform: &mut Transform,
     velocity: &mut KinematicVelocity,
     spatial_query: &SpatialQuery,
+    filter: &SpatialQueryFilter,
 ) {
-    let mut excluded_entities = vec![*entity];
-    excluded_entities.push(*entity);
     let mut remaining_velocity = velocity.0 * delta_time;
     for _ in 0..config.max_iterations {
         if let Some(hit) = spatial_query.cast_shape(
@@ -124,8 +136,7 @@ pub fn move_and_slide(
             transform.rotation,
             Dir3::new(remaining_velocity.normalize_or_zero()).unwrap_or(Dir3::X),
             &ShapeCastConfig::from_max_distance(remaining_velocity.length()),
-            &SpatialQueryFilter::default()
-                .with_excluded_entities(excluded_entities.iter().copied()),
+            &filter,
         ) {
             // Calculate our safe distances to move
             let safe_distance = (hit.distance - config.epsilon).max(0.0);


### PR DESCRIPTION
this makes it possible to configure what you want to collide/slide with and not.

TODO: what do we do with `Sensor`s? generally they should not be collided with even if the collision mask matches.