### PR TITLE
Use remaining_time instead of remaining_motion

### DIFF
--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -66,28 +66,30 @@ pub fn move_and_slide(
     };
 
     for _ in 0..config.max_iterations {
+        let motion = *velocity * delta_time;
+
         let Some((safe_movement, hit)) = character_sweep(
             collider,
             config.epsilon,
             *translation,
-            *velocity * delta_time,
+            motion,
             rotation,
             spatial_query,
             filter,
         ) else {
             // No collision, move the full remaining distance
-            *translation += *velocity * delta_time;
+            *translation += motion;
             break;
         };
+
+        // Trigger callbacks
+        on_hit(hit);
 
         // Move the transform to just before the point of collision
         *translation += safe_movement;
 
         // Project velocity and remaining motion onto the surface plane
         *velocity = velocity.reject_from(hit.normal1);
-
-        // Trigger callbacks
-        on_hit(hit);
 
         // Quake2: "If velocity is against original velocity, stop early to avoid tiny oscilations in sloping corners."
         if velocity.dot(*original_direction) <= 0.0 {

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -6,20 +6,19 @@ pub fn character_sweep(
     collider: &Collider,
     epsilon: f32,
     origin: Vec3,
-    motion: Vec3,
+    direction: Dir3,
+    max_distance: f32,
     rotation: Quat,
     spatial_query: &SpatialQuery,
     filter: &SpatialQueryFilter,
-) -> Option<(Vec3, ShapeHitData)> {
-    let (direction, length) = Dir3::new_and_length(motion).ok()?;
-
+) -> Option<(f32, ShapeHitData)> {
     let hit = spatial_query.cast_shape(
         collider,
         origin,
         rotation,
         direction,
         &ShapeCastConfig {
-            max_distance: length + epsilon, // extend the trace slightly
+            max_distance: max_distance + epsilon, // extend the trace slightly
             target_distance: epsilon, // I'm not sure what this does but I think this is correct ;)
             ignore_origin_penetration: true,
             ..Default::default()
@@ -28,9 +27,9 @@ pub fn character_sweep(
     )?;
 
     // How far is safe to translate by
-    let safe_movement = direction * (hit.distance - epsilon).max(0.0);
+    let safe_distance = (hit.distance - epsilon).max(0.0);
 
-    Some((safe_movement, hit))
+    Some((safe_distance, hit))
 }
 
 ////// EXAMPLE MOVEMENT /////////////
@@ -65,28 +64,36 @@ pub fn move_and_slide(
         return;
     };
 
+    let mut remaining_time = delta_time;
+
     for _ in 0..config.max_iterations {
-        let motion = *velocity * delta_time;
+        let Ok((direction, max_distance)) = Dir3::new_and_length(*velocity * remaining_time) else {
+            break;
+        };
 
         let Some((safe_movement, hit)) = character_sweep(
             collider,
             config.epsilon,
             *translation,
-            motion,
+            direction,
+            max_distance,
             rotation,
             spatial_query,
             filter,
         ) else {
             // No collision, move the full remaining distance
-            *translation += motion;
+            *translation += direction * max_distance;
             break;
         };
 
         // Trigger callbacks
         on_hit(hit);
 
+        // Progress time by the movement amount
+        remaining_time *= 1.0 - safe_movement / max_distance;
+
         // Move the transform to just before the point of collision
-        *translation += safe_movement;
+        *translation += direction * safe_movement;
 
         // Project velocity and remaining motion onto the surface plane
         *velocity = velocity.reject_from(hit.normal1);

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -156,13 +156,14 @@ fn movement(
                 collider,
                 config.epsilon,
                 transform.translation,
-                -character.up * 10.0, // arbitrary trace distance
+                -character.up,
+                10.0, // arbitrary trace distance
                 rotation,
                 &spatial_query,
                 &filter,
             ) {
                 if is_walkable(hit) {
-                    transform.translation += movement; // also snap to the floor
+                    transform.translation -= character.up * movement; // also snap to the floor
                     floor = Some(Dir3::new(hit.normal1).unwrap());
                 }
             }


### PR DESCRIPTION
This was done to avoid using `reject_from` on both remaining_motion and velocity. I stole it from https://github.com/BrianWiz/bg-rs/blob/596472c6a81aa58af3d2cce41de38094e96f4d76/core/src/plugins/character.rs#L126

Everything seems to still work but I could be wrong 😅