### PR TITLE
rename acceleration/friction functions and change return type to `Vec3`

### DIFF
--- a/src/movement.rs
+++ b/src/movement.rs
@@ -191,6 +191,7 @@ fn movement(
 }
 
 /// This is a simple example inspired by Quake, users are expected to bring their own logic for acceleration.
+#[must_use]
 fn acceleration(
     velocity: Vec3,
     direction: impl TryInto<Dir3>,
@@ -217,6 +218,7 @@ fn acceleration(
 }
 
 /// Constant acceleration in the opposite direction of velocity.
+#[must_use]
 pub fn friction(velocity: Vec3, friction: f32, delta: f32) -> Vec3 {
     let speed_sq = velocity.length_squared();
 


### PR DESCRIPTION
- changed the return types of `apply_friction` and `accelerate` from `Option` to `Vec3` since the `None` case can be expressed as `Vec3::ZERO`
- made them additive
- renamed them to `friction` and `acceleration` and made them `#[must_use]`