### PR TITLE
add `mut` to `move_and_slide` inputs

### DIFF
--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -60,8 +60,8 @@ pub struct MoveAndSlideResult {
 pub fn move_and_slide(
     spatial_query: &SpatialQuery,
     collider: &Collider,
-    translation: Vec3,
-    velocity: Vec3,
+    mut translation: Vec3,
+    mut velocity: Vec3,
     rotation: Quat,
     config: MoveAndSlideConfig,
     filter: &SpatialQueryFilter,
@@ -71,9 +71,6 @@ pub fn move_and_slide(
     let Ok(original_direction) = Dir3::new(velocity) else {
         return None;
     };
-
-    let mut translation = translation;
-    let mut velocity = velocity;
 
     let mut remaining_time = delta_time;
 


### PR DESCRIPTION
The function parameters where re-assigned as `mut` in the function body. Declared the inputs as mutable instead. 