### PR TITLE
Velocity projection change

### DIFF
--- a/src/camera/orbit_camera.rs
+++ b/src/camera/orbit_camera.rs
@@ -32,7 +32,7 @@ impl Default for SpringArm {
             distance: 4.0,
             target_distance: 4.0,
             recover_speed: 6.0,
-            collision_radius: 0.2,
+            collision_radius: 0.1,
             filters: LayerMask::ALL,
         }
     }

--- a/src/character.rs
+++ b/src/character.rs
@@ -178,7 +178,7 @@ pub fn project_motion_on_ground(motion: Vec3, normal: impl TryInto<Dir3>, up: Di
     let mut horizontal = motion - vertical;
 
     // Remove downward velocity
-    if vertical.dot(*up) < 0.0 {
+    if vertical.dot(*normal) < 0.0 {
         vertical = Vec3::ZERO;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn setup(
         Attachments::spawn_one((
             MainCamera,
             FollowOffset {
-                absolute: Vec3::Y * 0.75,
+                absolute: Vec3::Y * EXAMPLE_CHARACTER_CAPSULE_LENGTH / 2.0,
                 ..Default::default()
             },
             Camera {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
-use avian3d::{
-    PhysicsPlugins,
-    prelude::{PhysicsDebugPlugin, PhysicsDiagnosticsPlugin, PhysicsDiagnosticsUiPlugin},
-};
+use avian3d::{PhysicsPlugins, prelude::*};
 use bevy::{
     pbr::{Atmosphere, light_consts::lux},
     prelude::*,

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -1,5 +1,6 @@
 use avian3d::prelude::*;
 use bevy::prelude::*;
+
 const SIMILARITY_THRESHOLD: f32 = 0.999;
 
 /// Returns the safe hit distance and the hit data from the spatial query.

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -97,9 +97,12 @@ pub fn move_and_slide(
     // Callback that is called when a hit occurs.
     // If `false` is returned then the body will not slide during that iteration.
     mut on_hit: impl FnMut(&mut MoveAndSlideHit) -> bool,
-) -> Option<MoveAndSlideResult> {
+) -> MoveAndSlideResult {
     let Ok(original_direction) = Dir3::new(velocity) else {
-        return None;
+        return MoveAndSlideResult {
+            new_translation: translation,
+            new_velocity: velocity,
+        };
     };
 
     let mut remaining_time = delta_time;
@@ -157,41 +160,10 @@ pub fn move_and_slide(
         }
     }
 
-    Some(MoveAndSlideResult {
+    MoveAndSlideResult {
         new_translation: translation,
         new_velocity: velocity,
-    })
-}
-
-pub fn move_and_collide(
-    collider: &Collider,
-    origin: Vec3,
-    rotation: Quat,
-    motion: Vec3,
-    epsilon: f32,
-    spatial_query: &SpatialQuery,
-    filter: &SpatialQueryFilter,
-) -> (Vec3, Option<ShapeHitData>) {
-    let Ok((direction, max_distance)) = Dir3::new_and_length(motion) else {
-        return (Vec3::ZERO, None);
-    };
-
-    let Some((safe_distance, hit)) = sweep_check(
-        collider,
-        epsilon,
-        origin,
-        direction,
-        max_distance,
-        rotation,
-        spatial_query,
-        filter,
-    ) else {
-        // No collision, move the full distance
-        return (direction * max_distance, None);
-    };
-
-    // Move to just before the point of collision
-    (direction * safe_distance, Some(hit))
+    }
 }
 
 fn similar_plane(normal1: Vec3, normal2: Vec3) -> bool {

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -163,6 +163,37 @@ pub fn move_and_slide(
     })
 }
 
+pub fn move_and_collide(
+    collider: &Collider,
+    origin: Vec3,
+    rotation: Quat,
+    motion: Vec3,
+    epsilon: f32,
+    spatial_query: &SpatialQuery,
+    filter: &SpatialQueryFilter,
+) -> (Vec3, Option<ShapeHitData>) {
+    let Ok((direction, max_distance)) = Dir3::new_and_length(motion) else {
+        return (Vec3::ZERO, None);
+    };
+
+    let Some((safe_distance, hit)) = sweep_check(
+        collider,
+        epsilon,
+        origin,
+        direction,
+        max_distance,
+        rotation,
+        spatial_query,
+        filter,
+    ) else {
+        // No collision, move the full distance
+        return (direction * max_distance, None);
+    };
+
+    // Move to just before the point of collision
+    (direction * safe_distance, Some(hit))
+}
+
 fn similar_plane(normal1: Vec3, normal2: Vec3) -> bool {
     normal1.dot(normal2) > SIMILARITY_THRESHOLD
 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -390,7 +390,13 @@ fn try_step_up_on_hit(
         return None;
     };
 
-    if !is_walkable(hit.normal1, up, EXAMPLE_WALKABLE_ANGLE) {
+    if !is_walkable(
+        hit.normal1,
+        up,
+        // Subtract a small amount from walkable angle to make sure we can't step
+        // on surfaces that are nearly excactly the walkable angle of the character
+        EXAMPLE_WALKABLE_ANGLE - 1e-4,
+    ) {
         return None;
     }
 

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -220,13 +220,8 @@ fn movement(
                 if is_walkable(hit.hit_data.normal1, character.up, EXAMPLE_WALKABLE_ANGLE) {
                     new_ground = Some(Dir3::new(hit.hit_data.normal1).unwrap());
 
-                    if hit.substep == 0 {
-                        *hit.velocity = project_motion_on_ground(
-                            *hit.velocity,
-                            hit.hit_data.normal1,
-                            character.up,
-                        );
-                    }
+                    *hit.velocity =
+                        project_motion_on_ground(*hit.velocity, hit.hit_data.normal1, character.up);
 
                     return false;
                 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -173,6 +173,8 @@ fn movement(
         }
 
         // Sweep in the movement direction to find a plane to project acceleration on
+        // This is a seperate step because trying to do this in the `move_and_slide` callback
+        // results in "sticking" to the wall rather than sliding down at the expected rate
         if let Ok((direction, max_distance)) = Dir3::new_and_length(move_accel * time.delta_secs())
         {
             if let Some((safe_distance, hit)) = sweep_check(


### PR DESCRIPTION
This changes how velocity is projected on collision planes, namely:

- the resulting velocity from `move_and_slide` is no longer used, the velocity is changed during the callback instead
- there's an additional step before `move_and_slide` where we perform a sweep in the acceleration direction (movement input) to determine how the acceleration vector is projected. If it's a wall then `project_motion_on_wall` is used and if it's a floor then `project_motion_on_ground` is used. The difference between the two functions are explained in the code.

The results of these changes are:

- when the character is moving into slopes it can't stand on, it's no longer able to climb up those slopes. 
- when walking diagonally up slopes the character is able to stand on, the acceleration direction will align with the floor normal but only vertically, leaving the horizontal direction unchanged.

This can be observer by walking diagonally up and down slopes on main and comparing it to this branch. On main you will end up on a different point on the ramp from where you started. On this branch you will end up exactly where you started.

This also fixes a stepping issue where the character would sometimes launch upwards after stepping.