### PR TITLE
Follow moving platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+rust-toolchain

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -94,8 +94,6 @@ pub fn move_and_slide(
     config: MoveAndSlideConfig,
     filter: &SpatialQueryFilter,
     delta_time: f32,
-    // Callback that is called when a hit occurs.
-    // If `false` is returned then the body will not slide during that iteration.
     mut on_hit: impl FnMut(&mut MoveAndSlideHit) -> bool,
 ) -> MoveAndSlideResult {
     let Ok(original_direction) = Dir3::new(velocity) else {


### PR DESCRIPTION
Works for both translation and rotation. The platform velocity (calculated from previous transform) is added to the character velocity when the character leaves the platform.

fixes #8 
