### PR TITLE
Generalize sliding behaviour

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -172,6 +172,7 @@ pub fn ground_check(
 ///
 /// **Panics** if the `normal` is zero, infinite or `NaN`.
 #[track_caller]
+#[must_use]
 pub fn project_motion(
     motion: Vec3,
     normal: impl TryInto<Dir3>,
@@ -194,6 +195,7 @@ pub fn project_motion(
 ///
 /// **Panics** if the `normal` is zero, infinite or `NaN`.
 #[track_caller]
+#[must_use]
 pub fn project_motion_on_ground(motion: Vec3, normal: impl TryInto<Dir3>, up: Dir3) -> Vec3 {
     let normal = normal
         .try_into()
@@ -233,6 +235,7 @@ pub fn project_motion_on_ground(motion: Vec3, normal: impl TryInto<Dir3>, up: Di
 ///
 /// **Panics** if the `normal` is zero, infinite or `NaN`.
 #[track_caller]
+#[must_use]
 pub fn project_motion_on_wall(motion: Vec3, normal: impl TryInto<Dir3>, up: Dir3) -> Vec3 {
     let normal = normal
         .try_into()
@@ -258,6 +261,7 @@ pub fn project_motion_on_wall(motion: Vec3, normal: impl TryInto<Dir3>, up: Dir3
 /// Transform a point that's relative to a previous transform to a new transform's space.
 ///
 /// Returns the new world-space position of the point.
+#[must_use]
 pub fn transform_moving_point(
     point: Vec3,
     current_transform: &GlobalTransform,
@@ -274,6 +278,7 @@ pub fn transform_moving_point(
 }
 
 /// Get the motion of a moving transform at the given `point`.
+#[must_use]
 pub fn motion_on_point(
     point: Vec3,
     current_transform: &GlobalTransform,

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -70,6 +70,16 @@ pub(crate) struct Slide {
     pub remaining_motion: f32,
 }
 
+impl Slide {
+    pub fn project_motion(self) -> SlideResult {
+        SlideResult {
+            translation: self.translation,
+            velocity: self.plane.project_motion(self.velocity),
+            elapsed_time: 0.0,
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct SlideResult {
     /// The new translation after sliding.
@@ -86,8 +96,6 @@ pub(crate) struct SlideResult {
 
 /// Pure function that returns new translation and velocity based on the current translation,
 /// velocity, and rotation.
-///
-/// If `on_hit` returns with `SlideOutput::skip_slide` set to true then the `collider` will not slide during that iteration.
 ///
 /// Keeping this as `pub(crate)` for now so I can keep `Slide` and `SlideOutput` as `pub(crate)`.
 /// This is so we can get warnings about unused types/properties which is very useful when deciding whether

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -52,7 +52,7 @@ impl Default for MoveAndSlideConfig {
 }
 
 /// Result of the move_and_slide function.
-pub(crate) struct MoveAndSlideResult {
+pub struct MoveAndSlideResult {
     pub translation: Vec3,
     pub velocity: Vec3,
     pub remaining_time: f32,
@@ -60,7 +60,7 @@ pub(crate) struct MoveAndSlideResult {
     pub applied_motion: Vec3,
 }
 
-pub(crate) struct Slide {
+pub struct Slide {
     pub hit: ShapeHitData,
     pub plane: PlaneType,
     pub translation: Vec3,
@@ -81,7 +81,7 @@ impl Slide {
 }
 
 #[derive(Default)]
-pub(crate) struct SlideResult {
+pub struct SlideResult {
     /// The new translation after sliding.
     pub translation: Vec3,
     /// The new velocity after sliding.
@@ -96,11 +96,7 @@ pub(crate) struct SlideResult {
 
 /// Pure function that returns new translation and velocity based on the current translation,
 /// velocity, and rotation.
-///
-/// Keeping this as `pub(crate)` for now so I can keep `Slide` and `SlideOutput` as `pub(crate)`.
-/// This is so we can get warnings about unused types/properties which is very useful when deciding whether
-/// or not it's safe to delete stuff.
-pub(crate) fn move_and_slide(
+pub fn move_and_slide(
     spatial_query: &SpatialQuery,
     collider: &Collider,
     origin: Vec3,
@@ -190,10 +186,10 @@ pub(crate) fn move_and_slide(
 }
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct SlidePlanes(pub Vec<Dir3>); // TODO: smallvec
+pub struct SlidePlanes(pub Vec<Dir3>); // TODO: smallvec
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum PlaneType {
+pub enum PlaneType {
     Plane(Dir3),
     Crease { crease: Dir3, planes: [Dir3; 2] },
     Corner([Dir3; 3]),

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -6,10 +6,7 @@ use avian3d::{
     },
     sync::PreviousGlobalTransform,
 };
-use bevy::{
-    color::palettes::css::{BLACK, BLUE, GREEN, RED, WHITE, YELLOW},
-    prelude::*,
-};
+use bevy::{color::palettes::css::*, prelude::*};
 use bevy_enhanced_input::prelude::{ActionState, Actions};
 
 use crate::{
@@ -311,6 +308,9 @@ fn movement(
             character.config,
             &filter.0,
             time.delta_secs(),
+            // Sliding works differently for the character velocity and the move and slide velocity state
+            // When the character is grounded we want to preserve it's horizontal velocity to avoid slowing down or bouncing off small obstacles
+            // Meanwhile, the move and slide velocity must always be perpendicular to the plane normal in order to progress the simulation in the next step
             |Slide {
                  hit,
                  plane,


### PR DESCRIPTION
#33 required overriding the default `move_and_slide` plane projection behavior in the `on_hit` callback function, to the point where the default behavour was barely used. I decided to change it so the `move_and_slide` function no longer does any sliding at all, instead it must be done manually in the callback.

This can be super simple like:

```rust
let move_result = move_and_slide(..., Slide::project_motion);
```

Or super complicated like the way we currently do it in [`movement.rs`](https://github.com/Ploruto/kcc_prototyping/blob/5d5158def087e7a5807295b87ea244cb99db7d6e/src/movement.rs#L314).

- the `on_hit` callback now takes a `Slide` input and returns a `SlideResult` to avoid having `&mut` references in the input parameter
- the hits `Vec` in `move_and_slide` have been replaced with a wrapper which guarantees that there are only one instance of every plane normal, which simplifies the sliding logic
- the plane sliding in `move_and_slide` have been moved to the `on_hit` callback function, although it's not identical because of the simplified approach