### PR TITLE
Fix inputs being delayed by one frame

### DIFF
--- a/src/camera/fly_camera.rs
+++ b/src/camera/fly_camera.rs
@@ -5,7 +5,10 @@ use bevy_enhanced_input::prelude::*;
 use super::Attachments;
 
 pub(crate) fn plugin(app: &mut App) {
-    app.add_systems(Update, fly_input);
+    app.add_systems(
+        RunFixedMainLoop,
+        fly_input.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
+    );
 }
 
 #[derive(Component, Reflect, Debug)]

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -22,10 +22,7 @@ impl Plugin for CameraPlugin {
             RunFixedMainLoop,
             view_input.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
         );
-        app.add_systems(
-            RunFixedMainLoop,
-            update_origin.in_set(RunFixedMainLoopSystem::AfterFixedMainLoop),
-        );
+        app.add_systems(Update, update_origin);
         app.add_observer(toggle_cam_perspective);
         app.add_observer(toggle_fly_cam);
     }

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -18,7 +18,14 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((fly_camera::plugin, orbit_camera::plugin));
-        app.add_systems(Update, (view_input, update_origin).chain());
+        app.add_systems(
+            RunFixedMainLoop,
+            view_input.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
+        );
+        app.add_systems(
+            RunFixedMainLoop,
+            update_origin.in_set(RunFixedMainLoopSystem::AfterFixedMainLoop),
+        );
         app.add_observer(toggle_cam_perspective);
         app.add_observer(toggle_fly_cam);
     }

--- a/src/camera/orbit_camera.rs
+++ b/src/camera/orbit_camera.rs
@@ -9,9 +9,10 @@ use bevy_enhanced_input::prelude::*;
 
 pub(crate) fn plugin(app: &mut App) {
     app.add_systems(
-        Update,
+        RunFixedMainLoop,
         (zoom_input, update_spring_arm)
             .chain()
+            .in_set(RunFixedMainLoopSystem::AfterFixedMainLoop)
             .after(super::update_origin),
     );
 }

--- a/src/camera/orbit_camera.rs
+++ b/src/camera/orbit_camera.rs
@@ -12,12 +12,7 @@ pub(crate) fn plugin(app: &mut App) {
         RunFixedMainLoop,
         zoom_input.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
     );
-    app.add_systems(
-        RunFixedMainLoop,
-        update_spring_arm
-            .in_set(RunFixedMainLoopSystem::AfterFixedMainLoop)
-            .after(super::update_origin),
-    );
+    app.add_systems(Update, update_spring_arm.after(super::update_origin));
 }
 
 #[derive(Component, Reflect, Debug, Clone, Copy)]

--- a/src/camera/orbit_camera.rs
+++ b/src/camera/orbit_camera.rs
@@ -10,8 +10,11 @@ use bevy_enhanced_input::prelude::*;
 pub(crate) fn plugin(app: &mut App) {
     app.add_systems(
         RunFixedMainLoop,
-        (zoom_input, update_spring_arm)
-            .chain()
+        zoom_input.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
+    );
+    app.add_systems(
+        RunFixedMainLoop,
+        update_spring_arm
             .in_set(RunFixedMainLoopSystem::AfterFixedMainLoop)
             .after(super::update_origin),
     );

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -27,7 +27,10 @@ impl Plugin for KCCPlugin {
             FixedUpdate,
             (movement, platform_movement.after(PhysicsSet::Sync)),
         );
-        app.add_systems(Update, jump_input);
+        app.add_systems(
+            RunFixedMainLoop,
+            jump_input.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
+        );
     }
 }
 


### PR DESCRIPTION
Now, all inputs are resolved before the physics systems.
Note that this is a pitfall you cannot run into when using bevy_enhanced_input's observer-based API, as that is resolved in `PreUpdate`.

`RunFixedMainLoop, foo.in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop)` is the last variable timestep schedule that is run every frame *right before* the fixed timestep loop is evaluated.